### PR TITLE
Namespace the attributes to avoid name collisions

### DIFF
--- a/app/src/main/java/com/woalk/apps/lib/colorpicker/ColorPreference.java
+++ b/app/src/main/java/com/woalk/apps/lib/colorpicker/ColorPreference.java
@@ -38,22 +38,22 @@ public class ColorPreference extends Preference implements ColorPickerSwatch
         TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable
                 .ColorPreference, 0, 0);
         try {
-            int id = a.getResourceId(R.styleable.ColorPreference_colors, 0);
+            int id = a.getResourceId(R.styleable.ColorPreference_acpColors, 0);
             if (id != 0) {
                 mColors = getContext().getResources().getIntArray(id);
             }
-            id = a.getResourceId(R.styleable.ColorPreference_dialogTitle, 0);
+            id = a.getResourceId(R.styleable.ColorPreference_acpDialogTitle, 0);
             if (id != 0) {
                 mTitle = getContext().getResources().getString(id);
             } else { // use string
-                mTitle = a.getString(R.styleable.ColorPreference_dialogTitle);
+                mTitle = a.getString(R.styleable.ColorPreference_acpDialogTitle);
                 if (mTitle == null) {
                     mTitle = getContext().getResources().getString(R.string
                             .color_picker_default_title);
                 }
             }
-            mColumns = a.getInt(R.styleable.ColorPreference_columns, 2);
-            mAllowCustomColor = a.getBoolean(R.styleable.ColorPreference_allowCustomColor, false);
+            mColumns = a.getInt(R.styleable.ColorPreference_acpColumns, 2);
+            mAllowCustomColor = a.getBoolean(R.styleable.ColorPreference_acpAllowCustomColor, false);
         } finally {
             a.recycle();
         }

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="ColorPreference">
-        <attr name="dialogTitle" format="string|reference" />
-        <attr name="colors" format="reference" />
-        <attr name="columns" format="integer" />
-        <attr name="allowCustomColor" format="boolean" />
+        <attr name="acpDialogTitle" format="string|reference" />
+        <attr name="acpColors" format="reference" />
+        <attr name="acpColumns" format="integer" />
+        <attr name="acpAllowCustomColor" format="boolean" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
Hey @woalk!

I notice that this library can collide with some of the appcompat-v7 attributes when aapt(?) tries to merge the resources, so I had to prefix the custom attributes with a namespace (acp). After adding the prefix, Gradle manages to sync everything as expected. :+1: 

Feel free to include this in your base repo if you wish. :-)

Thanks!
